### PR TITLE
Feature: List Nuget Packages

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+### 2.1.0
+* Added endpoint (/packages) which lists the nuget packages used at compile time for this application using the content of the packages.config file, if it is found in the application directory.
 ### 2.0.0
 * Add version information to response from API
 	* This is done to allow extending the response in future releases

--- a/src/Okanshi/AssemblyInfo.fs
+++ b/src/Okanshi/AssemblyInfo.fs
@@ -4,9 +4,9 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("Okanshi")>]
 [<assembly: AssemblyProductAttribute("Okanshi")>]
 [<assembly: AssemblyDescriptionAttribute("In-process monitoring solution")>]
-[<assembly: AssemblyFileVersionAttribute("1.0.1")>]
+[<assembly: AssemblyFileVersionAttribute("1.1.1")>]
 [<assembly: AssemblyVersionAttribute("1.0.0")>]
-[<assembly: AssemblyInformationalVersionAttribute("1.0.1")>]
+[<assembly: AssemblyInformationalVersionAttribute("1.1.1")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/Okanshi/MonitorApi.fs
+++ b/src/Okanshi/MonitorApi.fs
@@ -13,6 +13,14 @@ type Dependency =
         Version : string;
     }
 
+type Package =
+    {
+        /// Id of the package
+        Id : string;
+        /// The package version
+        Version : string;
+    }
+
 /// Api options
 type MonitorApiOptions() =
     /// Enable CORS request. Default value is false

--- a/src/Okanshi/Okanshi.fsproj
+++ b/src/Okanshi/Okanshi.fsproj
@@ -92,6 +92,7 @@
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Feature request.

Adds a /packages entry point.
Prerequest: Packages config was copied to the outdir during compile and deployed with the application.

This new entry point scans the immediate directory for the presence of a packages.config.
If found it is parsed and the result is returned in an {Id,Version} format, much like the /dependencies entry point.

This feature allows a individual to extract both binary dependency version as well as package version for bug tracing / dependency mapping etc.