### PR TITLE
Improve thread safety

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 * Add new NuGet package with support for OWIN.
 * Added support for registering a custom timing by providing a number describing the elapsed number of milliseconds.
 * Improved performance when using OkanshiMonitor to get monitors
+* Ensured thread safety in metric types by using locks where needed
 
 ### 4.0.0-beta
 

--- a/src/Okanshi/Helpers.fs
+++ b/src/Okanshi/Helpers.fs
@@ -1,0 +1,13 @@
+﻿namespace Okanshi.Helpers
+
+[<AutoOpen>]
+module Lock = 
+    let lock = lock
+    
+    let inline lockWithArg (lockObj : 'T when 'T : not struct) arg f = 
+        let mutable lockTaken = false
+        try 
+            System.Threading.Monitor.Enter(lockObj, ref lockTaken)
+            f arg
+        finally
+            if lockTaken then System.Threading.Monitor.Exit(lockObj)

--- a/src/Okanshi/Okanshi.fsproj
+++ b/src/Okanshi/Okanshi.fsproj
@@ -43,6 +43,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Helpers.fs" />
     <Compile Include="Clock.fs" />
     <Compile Include="Atomic.fs" />
     <Compile Include="Config.fs" />


### PR DESCRIPTION
Ensures that composite metrics are thread-safe. This closes #30 when merged