### PR TITLE
Freeze clock

### DIFF
--- a/src/Okanshi/Atomic.fs
+++ b/src/Okanshi/Atomic.fs
@@ -181,7 +181,7 @@ type StepLong(initialValue, step : TimeSpan, clock : IClock) as self =
 
     let increment' amount = self.GetCurrent().Increment(amount)
 
-    new(interval) = new StepLong(0L, interval, SystemClock.Instance)
+    new(interval) = new StepLong(0L, interval, new SystemClock())
     new(interval, clock) = new StepLong(0L, interval, clock)
     
     // Gets the current count

--- a/src/Okanshi/Clock.fs
+++ b/src/Okanshi/Clock.fs
@@ -3,85 +3,91 @@ namespace Okanshi
 open System
 
 /// Interface for defining the clock used
-type IClock =
+type IClock = 
+    
     /// Gets the current time
-    abstract member Now : unit -> DateTime
+    abstract Now : unit -> DateTime
+    
     /// Gets the current ticks
-    abstract member NowTicks : unit -> int64
+    abstract NowTicks : unit -> int64
+    
     /// Freezes the time. Used to make sure composite metrics go into the same
     /// buckets across atomics
-    abstract member Freeze : unit -> unit
+    abstract Freeze : unit -> unit
+    
     /// Unfreezes the time
-    abstract member Unfreeze : unit -> unit
+    abstract Unfreeze : unit -> unit
 
 /// Wrapper around the system time
-type SystemClock() =
+type SystemClock() = 
     static let instance = new SystemClock()
     let mutable frozenAt : DateTime option = None
-
     let freeze() = frozenAt <- Some(DateTime.UtcNow)
     let unfreeze() = frozenAt <- None
     
-    let now() =
+    let now() = 
         match frozenAt with
         | Some(x) -> x
         | None -> DateTime.UtcNow
-
+    
     /// Gets the current time
-    member __.Now() =
+    member __.Now() = 
         match frozenAt with
         | Some(x) -> x
         | None -> DateTime.UtcNow
     
     /// Gets the current ticks
     member self.NowTicks() = self.Now().Ticks
-
+    
     /// Freezes the time. Used to make sure composite metrics go into the same
     /// buckets across atomics
-    member __.Freeze() =
-        frozenAt <- Some(DateTime.UtcNow)
-
+    member __.Freeze() = frozenAt <- Some(DateTime.UtcNow)
+    
     /// Unfreezes the time
-    member __.Unfreeze() =
-        frozenAt <- None
-
+    member __.Unfreeze() = frozenAt <- None
+    
     static member Instance = instance
-
     interface IClock with
+        
         /// Gets the current time
         member self.Now() = self.Now()
+        
         /// Gets the current ticks
         member self.NowTicks() = self.NowTicks()
+        
         /// Freezes the time. Used to make sure composite metrics go into the same
         /// buckets across atomics
         member self.Freeze() = ()
+        
         /// Unfreezes the time
         member self.Unfreeze() = ()
 
 /// Manual clock, should only be used in tests
-type ManualClock() =
+type ManualClock() = 
     let mutable currentTime = DateTime.UtcNow
-
+    
     /// Gets the current time
     member __.Now() = currentTime
-
+    
     /// Gets the current ticks
     member __.NowTicks() = currentTime.Ticks
-
+    
     /// Sets time current time
-    member __.Set(time : DateTime) =
-        currentTime <- time
-
+    member __.Set(time : DateTime) = currentTime <- time
+    
     /// Advance the time
-    member __.Advance(span : TimeSpan) =
-        currentTime <- currentTime.Add(span)
-
+    member __.Advance(span : TimeSpan) = currentTime <- currentTime.Add(span)
+    
     interface IClock with
+        
         /// Gets the current time
         member self.Now() = self.Now()
+        
         /// Gets the current ticks
         member self.NowTicks() = self.NowTicks()
+        
         /// Does nothing in ManualClock, as time is always frozen
         member self.Freeze() = ()
+        
         /// Does nothing in ManualClock, as time is always frozen
         member self.Unfreeze() = ()

--- a/src/Okanshi/Clock.fs
+++ b/src/Okanshi/Clock.fs
@@ -20,7 +20,6 @@ type IClock =
 
 /// Wrapper around the system time
 type SystemClock() = 
-    static let instance = new SystemClock()
     let mutable frozenAt : DateTime option = None
     let freeze() = frozenAt <- Some(DateTime.UtcNow)
     let unfreeze() = frozenAt <- None
@@ -46,7 +45,6 @@ type SystemClock() =
     /// Unfreezes the time
     member __.Unfreeze() = frozenAt <- None
     
-    static member Instance = instance
     interface IClock with
         
         /// Gets the current time

--- a/src/Okanshi/Counters.fs
+++ b/src/Okanshi/Counters.fs
@@ -18,7 +18,7 @@ type StepCounter(config : MonitorConfig, step : TimeSpan, clock : IClock) =
     let stepMilliseconds = double step.TotalMilliseconds
     let stepsPerSecond = double 1000 / stepMilliseconds
 
-    new(config, step) = new StepCounter(config, step, SystemClock.Instance)
+    new(config, step) = new StepCounter(config, step, new SystemClock())
     
     /// Increment the counter by one
     member __.Increment() = value.Increment(1L) |> ignore
@@ -50,7 +50,7 @@ type PeakRateCounter(config : MonitorConfig, step, clock : IClock) =
 
     let getValue' () = peakRate.Poll().Value
 
-    new(config, step) = new PeakRateCounter(config, step, SystemClock.Instance)
+    new(config, step) = new PeakRateCounter(config, step, new SystemClock())
     
     /// Gets the peak rate within the specified interval
     member __.GetValue() = lock syncRoot getValue'
@@ -90,7 +90,7 @@ type DoubleCounter(config : MonitorConfig, step : TimeSpan, clock : IClock) =
             if current.CompareAndSet(nextDouble, originalValue) <> originalValue then loop()
         loop()
 
-    new(config, step) = new DoubleCounter(config, step, SystemClock.Instance)
+    new(config, step) = new DoubleCounter(config, step, new SystemClock())
     
     /// Increment the value by the specified amount
     member __.Increment(amount : double) = 

--- a/src/Okanshi/Gauges.fs
+++ b/src/Okanshi/Gauges.fs
@@ -144,7 +144,7 @@ type AverageGauge(config : MonitorConfig, step : TimeSpan, clock : IClock) =
         let original = value.GetCurrent().Get()
         value.GetCurrent().Set(((original * (count - 1L)) + v) / count)
 
-    new (config, step) = AverageGauge(config, step, SystemClock.Instance)
+    new (config, step) = AverageGauge(config, step, new SystemClock())
 
     /// Sets the value
     member __.Set(newValue) =

--- a/src/Okanshi/Gauges.fs
+++ b/src/Okanshi/Gauges.fs
@@ -140,9 +140,11 @@ type AverageGauge(config : MonitorConfig, step : TimeSpan, clock : IClock) =
     let syncRoot = new obj()
 
     let rec updateAverage v =
+        clock.Freeze()
         let count = count.Increment(1L)
         let original = value.GetCurrent().Get()
         value.GetCurrent().Set(((original * (count - 1L)) + v) / count)
+        clock.Unfreeze()
 
     new (config, step) = AverageGauge(config, step, new SystemClock())
 

--- a/src/Okanshi/Timers.fs
+++ b/src/Okanshi/Timers.fs
@@ -95,7 +95,7 @@ type BasicTimer(registry : IMonitorRegistry, config : MonitorConfig, step, clock
         registry.Register(count)
         registry.Register(total)
     
-    new(config, step) = BasicTimer(config, step, SystemClock.Instance)
+    new(config, step) = BasicTimer(config, step, new SystemClock())
     new(config, step, clock : IClock) = BasicTimer(DefaultMonitorRegistry.Instance, config, step, clock)
     
     /// Time a System.Func call and return the value

--- a/src/Okanshi/Timers.fs
+++ b/src/Okanshi/Timers.fs
@@ -69,11 +69,13 @@ type BasicTimer(registry : IMonitorRegistry, config : MonitorConfig, step, clock
     let syncRoot = new obj()
 
     let updateStatistics' elapsed =
+        clock.Freeze()
         count.Increment() |> ignore
         rate.Increment() |> ignore
         total.Increment(elapsed)
         max.Set(elapsed)
         min.Set(elapsed)
+        clock.Unfreeze()
     
     let updateStatistics elapsed = 
         lockWithArg syncRoot elapsed updateStatistics'

--- a/tests/Okanshi.Tests/Okanshi.Tests.csproj
+++ b/tests/Okanshi.Tests/Okanshi.Tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StepCounterTest.cs" />
     <Compile Include="StepLongTest.cs" />
+    <Compile Include="SystemClockTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="paket.references" />

--- a/tests/Okanshi.Tests/SystemClockTest.cs
+++ b/tests/Okanshi.Tests/SystemClockTest.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading;
+using FluentAssertions;
+using Xunit;
+
+namespace Okanshi.Test {
+    public class SystemClockTest
+    {
+        private readonly SystemClock systemClock;
+
+        public SystemClockTest()
+        {
+            systemClock = new SystemClock();
+        }
+
+        [Fact]
+        public void Now_returns_utc_now()
+        {
+            var now = systemClock.Now();
+
+            now.Should().BeCloseTo(DateTime.UtcNow);
+        }
+
+        [Fact]
+        public void NowTicks_returns_utc_now_ticks()
+        {
+            var now = systemClock.NowTicks();
+
+            now.Should().BeInRange(DateTime.UtcNow.AddSeconds(-1).Ticks, DateTime.UtcNow.AddSeconds(1).Ticks);
+        }
+
+        [Fact]
+        public void Freeze_freezes_the_clock()
+        {
+            var now = DateTime.UtcNow;
+            systemClock.Freeze();
+
+            var frozenTime = systemClock.Now();
+
+            Thread.Sleep(1000);
+            frozenTime.Should().BeCloseTo(now);
+        }
+
+        [Fact]
+        public void Unfreeze_starts_the_clock_again()
+        {
+            systemClock.Freeze();
+            Thread.Sleep(1000);
+
+            systemClock.Unfreeze();
+            systemClock.Now().Should().BeCloseTo(DateTime.UtcNow);
+        }
+    }
+}


### PR DESCRIPTION
The reason is to ensure that it is possible to maintain the same buckets when using step based features in composite metrics