### PR TITLE
Bugfix list of tags are ever-growing and attached to each measurement.

### DIFF
--- a/src/Okanshi.Owin/OkanshiMiddleware.cs
+++ b/src/Okanshi.Owin/OkanshiMiddleware.cs
@@ -11,7 +11,6 @@ namespace Okanshi.Owin
     {
         private readonly AppFunc next;
         private readonly OkanshiOwinOptions options;
-        private static readonly List<Tag> EmptyTagList = new List<Tag>();
 
         /// <summary>
         /// Create a new instance.
@@ -31,7 +30,7 @@ namespace Okanshi.Owin
             var timer = OkanshiTimer.StartNew(x => elapsed = x);
             await next.Invoke(environment);
             timer.Stop();
-            var tags = EmptyTagList;
+            var tags = new List<Tag>();
             if (options.AddStatusCodeTag)
             {
                 object responseCode;


### PR DESCRIPTION
A global list is populated with 2-3 tags on each request measurement. This means eventually and out-of-memory will occur. Additionally, measurements will have a prohibitive many tags associated with them.

This PR creates a new list each time