### PR TITLE
Add BasicTimer overloads on Register with TimeSpan and stopwatch

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 ### 6.0.0
 
 **BREAKING CHANGES**
-
+* `Timer.Register(long)` has been removed. Replace use with `Timer.Register(StopWatch)` or `Timer.Register(TimeSpan)`
 * `OkanshiMonitor.HealthCheck()` has been removed. Replace use with a `Gauge`
 * `LongTaskTimer` has been removed
 * BasicCounter has been renamed to CumulativeCounter to better explain what it does

--- a/src/Okanshi.Owin/OkanshiMiddleware.cs
+++ b/src/Okanshi.Owin/OkanshiMiddleware.cs
@@ -41,7 +41,7 @@ namespace Okanshi.Owin
             tags.Add(new Tag("path", environment["owin.RequestPath"].ToString()));
             tags.Add(new Tag("method", environment["owin.RequestMethod"].ToString()));
             var okanshiTimer = OkanshiMonitor.Timer(options.MetricName, tags.ToArray());
-            okanshiTimer.Register(timer.ElapsedMilliseconds);
+            okanshiTimer.RegisterElapsed(timer);
         }
     }
 }

--- a/src/Okanshi/Timers.fs
+++ b/src/Okanshi/Timers.fs
@@ -79,6 +79,12 @@ type ITimer =
     /// Manually register a timing, should only be used in special case
     abstract Register : int64 -> unit
 
+    /// Manually register a timing, should used when you can't call Record since you at the call time do not know the timer to use
+    abstract Register : Stopwatch -> unit
+
+    /// Manually register a timing, should used when you can't call Record since you at the call time do not know the timer to use
+    abstract Register : TimeSpan -> unit
+
 /// A simple timer providing the total time, count, min and max for the times that have been recorded
 type Timer(config : MonitorConfig, stopwatchFactory : Func<IStopwatch>) as self = 
     
@@ -161,7 +167,13 @@ type Timer(config : MonitorConfig, stopwatchFactory : Func<IStopwatch>) as self 
         OkanshiTimer((fun x -> updateStatistics x), (fun () -> stopwatchFactory.Invoke()))
 
     /// Manually register a timing, should only be used in special case
-    member __.Register(elapsed) = elapsed |> updateStatistics
+    member __.Register(elapsed : int64) = elapsed |> updateStatistics
+
+    /// Manually register a timing, should used when you can't call Record since you at the call time do not know the timer to use
+    member __.Register(stopwatch : Stopwatch) = self.Register(stopwatch.ElapsedMilliseconds)
+
+    /// Manually register a timing, should used when you can't call Record since you at the call time do not know the timer to use
+    member __.Register(elapsed : TimeSpan) = self.Register(int64(elapsed.TotalMilliseconds))
 
     /// Gets the value and resets the monitor
     member __.GetValuesAndReset() = Lock.lock syncRoot getValuesAndReset'
@@ -172,5 +184,7 @@ type Timer(config : MonitorConfig, stopwatchFactory : Func<IStopwatch>) as self 
         member self.GetValues() = self.GetValues() |> Seq.cast
         member self.Config = self.Config
         member self.Start() = self.Start()
-        member self.Register(elapsed) = self.Register(elapsed)
+        member self.Register(elapsed : int64) = self.Register(elapsed)
+        member self.Register(elapsed : Stopwatch) = self.Register(elapsed)
+        member self.Register(elapsed : TimeSpan) = self.Register(elapsed)
         member self.GetValuesAndReset() = self.GetValuesAndReset() |> Seq.cast

--- a/src/Okanshi/Timers.fs
+++ b/src/Okanshi/Timers.fs
@@ -79,8 +79,11 @@ type ITimer =
     /// Manually register a timing, should only be used in special case
     abstract Register : int64 -> unit
 
-    /// Manually register a timing, should used when you can't call Record since you at the call time do not know the timer to use
-    abstract Register : Stopwatch -> unit
+    /// Manually register a timing, should used when you can't call Record since you at the call time do not know the timer to use.
+    ///
+    /// You should stop the stopwatch before passing so you do not incur the overhead of Okanshi. But it is not a requirement. 
+    /// The stopwatch is not stopped by Okanshi.
+    abstract RegisterElapsed : Stopwatch -> unit
 
     /// Manually register a timing, should used when you can't call Record since you at the call time do not know the timer to use
     abstract Register : TimeSpan -> unit
@@ -169,8 +172,11 @@ type Timer(config : MonitorConfig, stopwatchFactory : Func<IStopwatch>) as self 
     /// Manually register a timing, should only be used in special case
     member __.Register(elapsed : int64) = elapsed |> updateStatistics
 
-    /// Manually register a timing, should used when you can't call Record since you at the call time do not know the timer to use
-    member __.Register(stopwatch : Stopwatch) = self.Register(stopwatch.ElapsedMilliseconds)
+    /// Manually register a timing, should used when you can't call Record since you at the call time do not know the timer to use.
+    ///
+    /// You should stop the stopwatch before passing so you do not incur the overhead of Okanshi. But it is not a requirement. 
+    /// The stopwatch is not stopped by Okanshi.
+    member __.RegisterElapsed(stopwatch : Stopwatch) = self.Register(stopwatch.ElapsedMilliseconds)
 
     /// Manually register a timing, should used when you can't call Record since you at the call time do not know the timer to use
     member __.Register(elapsed : TimeSpan) = self.Register(int64(elapsed.TotalMilliseconds))
@@ -185,6 +191,6 @@ type Timer(config : MonitorConfig, stopwatchFactory : Func<IStopwatch>) as self 
         member self.Config = self.Config
         member self.Start() = self.Start()
         member self.Register(elapsed : int64) = self.Register(elapsed)
-        member self.Register(elapsed : Stopwatch) = self.Register(elapsed)
+        member self.RegisterElapsed(elapsed : Stopwatch) = self.RegisterElapsed(elapsed)
         member self.Register(elapsed : TimeSpan) = self.Register(elapsed)
         member self.GetValuesAndReset() = self.GetValuesAndReset() |> Seq.cast

--- a/tests/Okanshi.Tests/TimerTest.cs
+++ b/tests/Okanshi.Tests/TimerTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using FluentAssertions;
@@ -231,13 +232,45 @@ namespace Okanshi.Test
         }
 
         [Fact]
-        public void Manual_registration_sets_total_time()
+        public void Manual_registration_with_long_sets_total_time()
         {
             const long elapsed = 1000;
 
             timer.Register(elapsed);
 
             timer.GetTotalTime().Value.Should().Be(elapsed);
+        }
+
+        [Fact]
+        public void Manual_registration_with_timespan_sets_total_time()
+        {
+            timer.Register(TimeSpan.FromSeconds(1));
+
+            timer.GetTotalTime().Value.Should().Be(1000);
+        }
+
+
+        [Fact]
+        public void Manual_registration_with_stopwatch_sets_total_time()
+        {
+            var sw = Stopwatch.StartNew();
+            Thread.Sleep(50);
+            sw.Stop();
+
+            timer.Register(sw);
+
+            timer.GetTotalTime().Value.Should().Be(sw.ElapsedMilliseconds);
+        }
+
+        [Fact]
+        public void Manual_registrations_accumulate_total_time()
+        {
+            const long elapsed = 1000;
+
+            timer.Register(elapsed);
+            timer.Register(elapsed);
+
+            timer.GetTotalTime().Value.Should().Be(2 * elapsed);
         }
 
         [Fact]

--- a/tests/Okanshi.Tests/TimerTest.cs
+++ b/tests/Okanshi.Tests/TimerTest.cs
@@ -206,8 +206,8 @@ namespace Okanshi.Test
         public void Manual_registration_updates_sets_max()
         {
             const long elapsed = 1000;
-
-            timer.Register(elapsed);
+            
+            timer.Register(TimeSpan.FromMilliseconds(elapsed));
 
             timer.GetMax().Value.Should().Be(elapsed);
         }
@@ -217,7 +217,7 @@ namespace Okanshi.Test
         {
             const long elapsed = 1000;
 
-            timer.Register(elapsed);
+            timer.Register(TimeSpan.FromMilliseconds(elapsed));
 
             timer.GetMin().Value.Should().Be(elapsed);
         }
@@ -226,7 +226,8 @@ namespace Okanshi.Test
         public void Manual_registration_sets_count()
         {
             const long elapsed = 1000;
-            timer.Register(elapsed);
+
+            timer.Register(TimeSpan.FromMilliseconds(elapsed));
 
             timer.GetCount().Value.Should().Be(1);
         }
@@ -236,7 +237,7 @@ namespace Okanshi.Test
         {
             const long elapsed = 1000;
 
-            timer.Register(elapsed);
+            timer.Register(TimeSpan.FromMilliseconds(elapsed));
 
             timer.GetTotalTime().Value.Should().Be(elapsed);
         }
@@ -267,8 +268,8 @@ namespace Okanshi.Test
         {
             const long elapsed = 1000;
 
-            timer.Register(elapsed);
-            timer.Register(elapsed);
+            timer.Register(TimeSpan.FromMilliseconds(elapsed));
+            timer.Register(TimeSpan.FromMilliseconds(elapsed));
 
             timer.GetTotalTime().Value.Should().Be(2 * elapsed);
         }

--- a/tests/Okanshi.Tests/TimerTest.cs
+++ b/tests/Okanshi.Tests/TimerTest.cs
@@ -257,7 +257,7 @@ namespace Okanshi.Test
             Thread.Sleep(50);
             sw.Stop();
 
-            timer.Register(sw);
+            timer.RegisterElapsed(sw);
 
             timer.GetTotalTime().Value.Should().Be(sw.ElapsedMilliseconds);
         }


### PR DESCRIPTION
The Register() is more common than maybe at first anticipated. This commit makes it easier to use Register() and ensure the user does not by mistake call a wrong method on StopWatch that returns a long