### PR TITLE
Fix registry interface bug

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### New in 6.1.0 (Unreleased)
+
+* Make IMonitorRegistry generic. This fixes a bug where behaviour is different depending on if the registry is stored as IMonitorRegistry or OkanshiMonitorRegistry
+
 ### 6.0.0
 
 The v6.0.0 release has done a major overhaul in the naming of monitors to make it simpler for new users of the API. 

--- a/src/Okanshi/Registry.fs
+++ b/src/Okanshi/Registry.fs
@@ -20,7 +20,7 @@ type IMonitorRegistry =
     abstract Clear : unit -> unit
     
     /// Get or add a new registration
-    abstract GetOrAdd : MonitorConfig * Func<MonitorConfig, IMonitor> -> IMonitor
+    abstract GetOrAdd<'a when 'a :> IMonitor> : MonitorConfig * Func<MonitorConfig, 'a> -> 'a
 
 /// Monitor registry used by the OkanshiMonitor. This registry allows registration of monitors
 /// with the same name, but different types
@@ -53,7 +53,7 @@ type OkanshiMonitorRegistry() =
         let hash = hash config typeof<'a>
         match monitors.TryGetValue(hash) with
         | true, x -> x :?> 'a
-        | _ -> 
+        | _ ->
             let monitor = factory.Invoke(config)
             monitors.Add(hash, monitor)
             monitor
@@ -71,7 +71,7 @@ type OkanshiMonitorRegistry() =
     member __.Clear() = Lock.lock syncRoot clear'
     
     /// Get or add a new registration
-    member __.GetOrAdd<'a when 'a :> IMonitor>(config, factory : Func<MonitorConfig, 'a>) = 
+    member __.GetOrAdd<'a when 'a :> IMonitor>(config, factory : Func<MonitorConfig, 'a>) =
         Lock.lockWithArg syncRoot (config, factory) getOrAdd'
     
     interface IMonitorRegistry with
@@ -79,7 +79,7 @@ type OkanshiMonitorRegistry() =
         member self.Unregister(monitor) = self.Unregister(monitor)
         member self.IsRegistered(monitor) = self.IsRegistered(monitor)
         member self.Clear() = self.Clear()
-        member self.GetOrAdd(config, factory) = self.GetOrAdd(config, factory)
+        member self.GetOrAdd<'a when 'a :> IMonitor>(config, factory : Func<MonitorConfig, 'a>) = self.GetOrAdd(config, factory)
         member __.Dispose() = ()
 
 /// The default monitor registry handled as a singleton. Currently this is a OkanshiMonitorRegistry.

--- a/tests/Okanshi.Tests/OkanshiMonitorRegistryTest.cs
+++ b/tests/Okanshi.Tests/OkanshiMonitorRegistryTest.cs
@@ -91,6 +91,40 @@ namespace Okanshi.Test
             _okanshiMonitorRegistry.GetRegisteredMonitors().Should().HaveCount(2);
         }
 
+        [Fact]
+        public void Monitor_can_be_unregistered()
+        {
+            var monitor = new FakeMonitor();
+            _okanshiMonitorRegistry.GetOrAdd(monitor.Config, _ => monitor);
+
+            _okanshiMonitorRegistry.Unregister(monitor);
+
+            _okanshiMonitorRegistry.GetRegisteredMonitors().Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Monitor_can_be_unregistered_when_recreated()
+        {
+            var monitor = new FakeMonitor();
+            _okanshiMonitorRegistry.GetOrAdd(monitor.Config, _ => monitor);
+
+            _okanshiMonitorRegistry.Unregister(new FakeMonitor());
+
+            _okanshiMonitorRegistry.GetRegisteredMonitors().Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Monitor_can_be_unrgistered_when_registry_is_used_as_interface()
+        {
+            IMonitorRegistry registry = new OkanshiMonitorRegistry();
+            var monitor = new FakeMonitor();
+            registry.GetOrAdd(monitor.Config, _ => monitor);
+
+            registry.Unregister(monitor);
+
+            registry.GetRegisteredMonitors().Should().BeEmpty();
+        }
+
         private class FakeMonitor : IMonitor
         {
             public FakeMonitor(IEnumerable<Tag> tags = null)


### PR DESCRIPTION
If the interface isn't generic it will behave differently depending on if the interface is used or not, meaning you would get different results if you store the registry as the interface or the implementation