### PR TITLE
Cleanup counter implementation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@
 * `SlaTimer` has been added. The timer makes it easy to track SLA-breaches.
 * `MinMaxAvgGauge` has been added. It allows you to detect extreme values that would otherwise disappear in an average calculation.
 * `OkanshiMonitor.DefaultStep` has been deleted since it was forgotten in an earlier clean up process.
+* Unnecessary calculation has been removed from `Counter`, and locks are no longer used in the counter, instead atomics are used.
+* `Counter` now allows increment by negative numbers.
 
 ### 6.0.0
 

--- a/documentation/6.0/tutorial.md
+++ b/documentation/6.0/tutorial.md
@@ -119,7 +119,7 @@ Counters are monitors that you can increment as needed. They are thread-safe by 
 
 #### 1.2.1. Counter 
 
-A `Counter` counts the number of events between polling. The value is a ```int``` and can be incremented using a ```int```.
+A `Counter` counts the number of events between polling. The value is a `long` and can be incremented using a `long`.
 
 ```csharp
     OkanshiMonitor.Counter("Name").Increment();
@@ -153,7 +153,7 @@ A `DoubleCounter` counts the number of events between polling. The value is a ``
 
 #### 1.2.3. CumulativeCounter 
 
-Is a counter that is never reset at runtime, but retained during the lifetime of the process. Other than that, it works exactly like all other counters. . The value is a ```int``` and can be incremented using a ```int```.
+Is a counter that is never reset at runtime, but retained during the lifetime of the process. Other than that, it works exactly like all other counters. . The value is a `long` and can be incremented using a `long`.
 
 This counter make sense to use then you don't want to take the polling interval into account, and instead post-process the data.
 

--- a/src/Okanshi/Counters.fs
+++ b/src/Okanshi/Counters.fs
@@ -33,14 +33,14 @@ type Counter(config : MonitorConfig) =
     
     /// Gets the value and resets the monitor
     member __.GetValuesAndReset() =
-        seq { yield Measurement("value", current.GetAndSet(0L)) } |> Seq.toList
+        [ Measurement("value", current.GetAndSet(0L)) ] |> List.toSeq
     
     interface ICounter<int64> with
         member self.Increment() = self.Increment()
         member self.Increment(amount) = self.Increment(amount)
         member self.GetValues() = self.GetValues() |> Seq.cast
         member self.Config = self.Config
-        member self.GetValuesAndReset() = self.GetValuesAndReset() |> List.toSeq |> Seq.cast
+        member self.GetValuesAndReset() = self.GetValuesAndReset() |> Seq.cast
 
 /// A simple double counter.
 type DoubleCounter(config : MonitorConfig) = 

--- a/src/Okanshi/Counters.fs
+++ b/src/Okanshi/Counters.fs
@@ -15,49 +15,32 @@ type ICounter<'T> =
 
 /// Tracking the count between polls
 type Counter(config : MonitorConfig) = 
-    let mutable peakRate = 0L
-    let mutable current = 0L
-    let syncRoot = new obj()
-
-    let getValue' () =
-        seq {
-            yield Measurement("value", peakRate)
-        }
-
-    let increment' amount =
-        current <- current + amount
-        if current > peakRate then peakRate <- current
-
-    let reset'() =
-        peakRate <- 0L
-        current <- 0L
-
-    let getValueAndReset'() =
-        let result = getValue'() |> Seq.toList
-        reset'()
-        result |> List.toSeq
+    let current = new AtomicLong()
     
     /// Gets the maximum count
-    member __.GetValues() = Lock.lock syncRoot getValue'
+    member __.GetValues() =
+        seq { yield Measurement("value", current.Get()) }
     
     /// Increment the value by one
     member self.Increment() = self.Increment(1L)
     
     /// Increment the value by the specified amount
-    member __.Increment(amount) = lockWithArg syncRoot amount increment'
+    member __.Increment(amount) =
+        current.Increment(amount) |> ignore
     
     /// Gets the configuration
     member __.Config = config
     
     /// Gets the value and resets the monitor
-    member __.GetValuesAndReset() = Lock.lock syncRoot getValueAndReset'
+    member __.GetValuesAndReset() =
+        seq { yield Measurement("value", current.GetAndSet(0L)) } |> Seq.toList
     
     interface ICounter<int64> with
         member self.Increment() = self.Increment()
         member self.Increment(amount) = self.Increment(amount)
         member self.GetValues() = self.GetValues() |> Seq.cast
         member self.Config = self.Config
-        member self.GetValuesAndReset() = self.GetValuesAndReset() |> Seq.cast
+        member self.GetValuesAndReset() = self.GetValuesAndReset() |> List.toSeq |> Seq.cast
 
 /// A simple double counter.
 type DoubleCounter(config : MonitorConfig) = 

--- a/tests/Okanshi.Tests/CounterTest.cs
+++ b/tests/Okanshi.Tests/CounterTest.cs
@@ -59,5 +59,13 @@ namespace Okanshi.Test
         {
             counter.GetValues().Single().Name.Should().Be("value");
         }
+
+        [Fact]
+        public void Increment_with_negative_values_works()
+        {
+            counter.Increment(-1);
+
+            counter.GetValues().Single().Value.Should().Be(-1);
+        }
     }
 }

--- a/tests/Okanshi.Tests/CounterTest.cs
+++ b/tests/Okanshi.Tests/CounterTest.cs
@@ -55,26 +55,6 @@ namespace Okanshi.Test
         }
 
         [Fact]
-        public void Incrementing_with_negative_numbers_does_not_change_the_value()
-        {
-            counter.Increment();
-
-            counter.Increment(-1);
-
-            counter.GetValues().First().Value.Should().Be(1);
-        }
-
-        [Fact]
-        public void Incrementing_with_negative_numbers_and_then_with_a_positive_does_not_change_the_value()
-        {
-            counter.Increment();
-            counter.Increment(-1);
-            counter.Increment();
-
-            counter.GetValues().First().Value.Should().Be(1);
-        }
-
-        [Fact]
         public void Value_is_called_value()
         {
             counter.GetValues().Single().Name.Should().Be("value");


### PR DESCRIPTION
Counter uses locks which is not needed, but removal was forgotten.
This also allows the counter to be incremented by negative numbers

Fixes #117 