### PR TITLE
Make Okanshi.Endpoint received a poller

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,8 +10,10 @@
 * `Counter` now allows increment by negative numbers.
 
 **BREAKING CHANGES**
+
 * Make IMonitorRegistry generic. This fixes a bug where behaviour is different depending on if the registry is stored as IMonitorRegistry or OkanshiMonitorRegistry
 * Instead of Okanshi.Endpoint depending on Newtonsoft.Json to do the JSON serialization, it now accepts a `Func` doing the serialization, which makes it possible for the user to control dependencies and serialization
+* `Okanshi.Endpoint` nows takes a poller to be able to easily avoid problems with multiple pollers on the default registry. This also removes `PollingInterval` and `CollectMetricsOnProcessExit` from `EndpointOptions`.
 
 ### 6.0.0
 

--- a/samples/Okanshi.Endpoint.Sample/Program.cs
+++ b/samples/Okanshi.Endpoint.Sample/Program.cs
@@ -19,7 +19,7 @@ namespace Okanshi.Endpoint.Sample
             var httpEndpoint = new MonitorEndpoint(new EndpointOptions {
                 PollingInterval = TimeSpan.FromSeconds(10),
                 NumberOfSamplesToStore = 100,
-            }, o => JsonConvert.SerializeObject(o, Formatting.Indented));
+            }, DefaultMonitorRegistry.Instance, o => JsonConvert.SerializeObject(o, Formatting.Indented));
             httpEndpoint.Start();
 
             while (true) {

--- a/samples/Okanshi.Endpoint.Sample/Program.cs
+++ b/samples/Okanshi.Endpoint.Sample/Program.cs
@@ -13,13 +13,13 @@ namespace Okanshi.Endpoint.Sample
             // Get the default registry instance. This is the registry used when adding metrics
             // through OkanshiMonitor.
             var registry = DefaultMonitorRegistry.Instance;
+            var poller = new MetricMonitorRegistryPoller(registry, TimeSpan.FromMinutes(1));
 
             // Create a HTTP endpoint, this listens on the default registry instance, gets the values
             // every 10 seconds and keeps the last 100 samples in memory
             var httpEndpoint = new MonitorEndpoint(new EndpointOptions {
-                PollingInterval = TimeSpan.FromSeconds(10),
                 NumberOfSamplesToStore = 100,
-            }, DefaultMonitorRegistry.Instance, o => JsonConvert.SerializeObject(o, Formatting.Indented));
+            }, poller, o => JsonConvert.SerializeObject(o, Formatting.Indented));
             httpEndpoint.Start();
 
             while (true) {


### PR DESCRIPTION
This is done to avoid issues when using multiple pollers in you program.
All pollers will normally reset the monitors which will cause incorrect
readings from the pollers.

fixes #121

Signed-off-by: Kim Christensen <kimworking@gmail.com>