### PR TITLE
Remove timerFactory from Okanshi.Owin

### DIFF
--- a/documentation/tutorial.md
+++ b/documentation/tutorial.md
@@ -560,9 +560,12 @@ To enable use the `AppBuilder` extension method, `UseOkanshi`:
     app.UseOkanshi()
 ```
 
-For configuration see the API reference.
+You can provide a `OkanshiOwinOptions` where you can define e.g. which timer to use (and thus also which registry) 
 
-Currently the OWIN integration always uses the default registry.
+
+
+
+
 
 
 (document sections maintained by https://github.com/kbilsted/AutonumberMarkdown)

--- a/src/Okanshi.Owin/AppBuilderExtensions.cs
+++ b/src/Okanshi.Owin/AppBuilderExtensions.cs
@@ -9,17 +9,15 @@ namespace Okanshi.Owin
     public static class AppBuilderExtensions
     {
         /// <summary>
-        /// Use Okanshi middleware for timining all the requests.
+        /// Use Okanshi middleware for timing all the requests.
         /// </summary>
         /// <param name="appBuilder">The AppBuilder to extend</param>
         /// <param name="options">The options</param>
-        /// <param name="timerFactory">An optional factory method for creating timers. If not set OkanshiMonitor is used.</param>
-        public static void UseOkanshi(this IAppBuilder appBuilder, OkanshiOwinOptions options = null, Func<string, Tag[], ITimer> timerFactory = null)
+        public static void UseOkanshi(this IAppBuilder appBuilder, OkanshiOwinOptions options = null)
         {
             appBuilder.Use(
                 typeof(OkanshiMiddleware), 
-                options ?? new OkanshiOwinOptions(),
-                timerFactory ?? ((name, tags) => OkanshiMonitor.Timer(name, tags))
+                options ?? new OkanshiOwinOptions()
                 );
         }
     }


### PR DESCRIPTION
We discussed not introducing an extra field in the UseOkanshi() method and put it into the options object. Somehow that did not happen. We clean this up now.